### PR TITLE
Added AttachedProperty IsDraggable and IsDragHandle + Logic

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.103",
     "rollForward": "latestMinor",
     "allowPrerelease": true
   }

--- a/samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj
+++ b/samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
     <Nullable>enable</Nullable>

--- a/samples/DragAndDropSample/DragAndDropSample.csproj
+++ b/samples/DragAndDropSample/DragAndDropSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
     <Nullable>enable</Nullable>

--- a/samples/DraggableDemo/DraggableDemo.csproj
+++ b/samples/DraggableDemo/DraggableDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
     <Nullable>enable</Nullable>

--- a/samples/DraggableDemo/MainWindow.axaml
+++ b/samples/DraggableDemo/MainWindow.axaml
@@ -152,6 +152,74 @@
       </ItemsControl>
     </TabItem>
 
+    <TabItem Header="Canvas (Advanced)">
+      <Grid Margin="20" ColumnDefinitions="*,*" RowDefinitions="Auto,*">
+        <TextBlock Grid.Column="0" Grid.Row="0" Width="500" TextWrapping="Wrap">
+          Set a control's draggability by setting or binding to AttachedProperty:<LineBreak />
+          id:CanvasDragBehavior.IsDraggable=&quot;True/False&quot;<LineBreak /><LineBreak />
+          This property must be set on a direct child of your Canvas or the Root-Control of your DataTemplate if used in an ItemsControl.
+        </TextBlock>
+        <Canvas Classes="draggable" Grid.Column="0" Grid.Row="1" Width="500" Height="300" Background="LightGray">
+          <Canvas.Styles>
+            <Style Selector="Canvas > :is(Control):dragging">
+              <Setter Property="ZIndex" Value="1" />
+            </Style>
+          </Canvas.Styles>
+          <Rectangle Fill="Blue" Width="60" Height="40" Canvas.Left="20" Canvas.Top="10" />
+          <Ellipse Fill="Red" Width="50" Height="50" Canvas.Left="120" Canvas.Top="30" />
+          <TextBlock Text="You can drag me!" Background="Transparent" Canvas.Left="40" Canvas.Top="140" />
+          <TextBlock Text="You can't drag me at all!" id:CanvasDragBehavior.IsDraggable="False" Background="Transparent" Canvas.Left="40" Canvas.Top="160" />
+          <StackPanel Orientation="Horizontal" Background="Transparent" id:CanvasDragBehavior.IsDraggable="{Binding #Draggable_Toggle_1.IsChecked}" Canvas.Left="40" Canvas.Top="180">
+            <TextBlock Text="You can toggle my draggabillity!" id:CanvasDragBehavior.IsDragHandle="True" />
+            <ToggleSwitch x:Name="Draggable_Toggle_1" />
+          </StackPanel>
+          <StackPanel Orientation="Horizontal">
+
+          </StackPanel>
+          <Panel Background="Purple" Width="80" Height="70" Canvas.Left="250" Canvas.Top="100" />
+        </Canvas>
+        <StackPanel Grid.Column="1" Grid.Row="0"  Width="500">
+          <TextBlock TextWrapping="Wrap">
+            Specifiy a child/descendant Control as DragHandle with AttachedProperty:<LineBreak />
+            id:CanvasDragBehavior.IsDragHandle=&quot;True/False&quot;<LineBreak /><LineBreak />
+            If at least one descendant has this property set to true, the control can only be dragged by that DragHandle.<LineBreak />
+            Multiple DragHandles can be defined on the same Object!<LineBreak />
+          </TextBlock>
+          <StackPanel Orientation="Horizontal" Spacing="5" Background="Transparent" HorizontalAlignment="Center">
+            <TextBlock Text="Toggle draggabillity for all items!" />
+            <ToggleSwitch x:Name="Draggable_Toggle_2" IsChecked="True" />
+          </StackPanel>
+        </StackPanel>
+        <ItemsControl Classes="draggable" Grid.Column="1" Grid.Row="1" ItemsSource="{Binding Items}" Width="500" Height="300" Background="LightGray">
+          <ItemsControl.Styles>
+            <Style Selector="ItemsControl > ContentPresenter" x:DataType="models:Item">
+              <Setter Property="(Canvas.Left)" Value="{Binding X}" />
+              <Setter Property="(Canvas.Top)" Value="{Binding Y}" />
+            </Style>
+            <Style Selector="ItemsControl > ContentPresenter:dragging">
+              <Setter Property="Opacity" Value="0.5" />
+              <Setter Property="ZIndex" Value="1" />
+            </Style>
+          </ItemsControl.Styles>
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <Canvas />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+          <ItemsControl.DataTemplates>
+            <DataTemplate DataType="models:Item">
+              <Panel id:CanvasDragBehavior.IsDraggable="{Binding #Draggable_Toggle_2.IsChecked}">
+                <Rectangle Fill="Black" Width="50" Height="50" />
+                <TextBlock Text="M" id:CanvasDragBehavior.IsDragHandle="True" Background="AliceBlue" Width="15" Height="15" HorizontalAlignment="Right" VerticalAlignment="Top" />
+                <TextBlock Text="M" id:CanvasDragBehavior.IsDragHandle="True" Background="AliceBlue" Width="15" Height="15" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
+              </Panel>
+            </DataTemplate>
+          </ItemsControl.DataTemplates>
+        </ItemsControl>
+      </Grid>
+
+    </TabItem>
+
     <TabItem Header="Grid">
       <Grid Classes="draggable" ColumnDefinitions="*,*,*" RowDefinitions="*,*,*" ShowGridLines="True" Width="500" Height="300" Background="LightGray">
         <Grid.Styles>

--- a/src/Avalonia.Xaml.Interactions.Draggable/ItemDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Draggable/ItemDragBehavior.cs
@@ -27,13 +27,13 @@ public class ItemDragBehavior : Behavior<Control>
     /// <summary>
     /// 
     /// </summary>
-    public static readonly StyledProperty<Orientation> OrientationProperty = 
+    public static readonly StyledProperty<Orientation> OrientationProperty =
         AvaloniaProperty.Register<ItemDragBehavior, Orientation>(nameof(Orientation));
 
     /// <summary>
     /// 
     /// </summary>
-    public static readonly StyledProperty<double> HorizontalDragThresholdProperty = 
+    public static readonly StyledProperty<double> HorizontalDragThresholdProperty =
         AvaloniaProperty.Register<ItemDragBehavior, double>(nameof(HorizontalDragThreshold), 3);
 
     /// <summary>
@@ -96,7 +96,7 @@ public class ItemDragBehavior : Behavior<Control>
     private void PointerPressed(object? sender, PointerPressedEventArgs e)
     {
         var properties = e.GetCurrentPoint(AssociatedObject).Properties;
-        if (properties.IsLeftButtonPressed 
+        if (properties.IsLeftButtonPressed
             && AssociatedObject?.Parent is ItemsControl itemsControl)
         {
             _enableDrag = true;
@@ -200,9 +200,9 @@ public class ItemDragBehavior : Behavior<Control>
             {
                 SetTranslateTransform(container, 0, 0);
             }
-  
+
             i++;
-        }  
+        }
     }
 
     private void RemoveTransforms(ItemsControl? itemsControl)
@@ -221,9 +221,9 @@ public class ItemDragBehavior : Behavior<Control>
             {
                 SetTranslateTransform(container, 0, 0);
             }
-  
+
             i++;
-        }  
+        }
     }
 
     private void MoveDraggedItem(ItemsControl? itemsControl, int draggedIndex, int targetIndex)
@@ -241,7 +241,7 @@ public class ItemDragBehavior : Behavior<Control>
         }
         else
         {
-            if (itemsControl?.Items is {IsReadOnly: false} itemCollection)
+            if (itemsControl?.Items is { IsReadOnly: false } itemCollection)
             {
                 var draggedItem = itemCollection[draggedIndex];
                 itemCollection.RemoveAt(draggedIndex);
@@ -250,7 +250,7 @@ public class ItemDragBehavior : Behavior<Control>
                 if (itemsControl is SelectingItemsControl selectingItemsControl)
                 {
                     selectingItemsControl.SelectedIndex = targetIndex;
-                } 
+                }
             }
         }
     }
@@ -340,8 +340,8 @@ public class ItemDragBehavior : Behavior<Control>
                 var targetStart = orientation == Orientation.Horizontal ? targetBounds.X : targetBounds.Y;
 
                 var targetMid = orientation == Orientation.Horizontal
-                    ? targetBounds.X + targetBounds.Width / 2
-                    : targetBounds.Y + targetBounds.Height / 2;
+                    ? targetBounds.X + (targetBounds.Width / 2)
+                    : targetBounds.Y + (targetBounds.Height / 2);
 
                 var targetIndex = _itemsControl.IndexFromContainer(targetContainer);
 


### PR DESCRIPTION
Hey, this is my first pull request ever 😬
I'll appreciate any feedback! 

Also thank you for this awesome library and all the great work you do in general for Avalonia!

---

# Summary

I needed more control over when a control can be dragged and where it needs to be clicked on to be dragged.

To accomplish this I introduced two `AttachedProperty` on `CanvasDragBehavior`:

- `CanvasDragBehavior.IsDraggable` can be set directly on the draggable Control to change it's draggability.
- `CanvasDragBehavior.IsDragHandle` can be set on any number of descendants of the draggable Control.
    - If `IsDragHandle` is not set on any descendant, the whole draggable Control acts as draghandle (current behavior).
    -  If `IsDragHandle` is set on at least one descendant, the draggable control can only be moved by cicking those descendants.

To showcase these properties in action, I added `Canvas (Advanced)`-tab to the `DraggableDemo`-Project:
![image](https://github.com/user-attachments/assets/36d17402-1bb9-4503-be81-35dacce36c8e)


# How does it work?

## IsDraggable

```csharp

// Set _rootControl in OnLoaded() 
_rootControl = AssociatedObject is ContentPresenter presenter ? presenter.Child : AssociatedObject;
...

// Check draggability in Pressed()
_rootControl?.GetValue(IsDraggableProperty) == true
...
```

## IsDragHandle

The approach of setting the property directly on the descendant required moving some of the logic in `OnAttachedToVisualTree()` to `OnLoaded()`, since the `GetVisualDescendants()` won't get any/all descendants when called from the former.

```csharp
            _dragHandles = AssociatedObject.GetVisualDescendants().Where(d => d.GetValue(IsDragHandleProperty));

            if (_dragHandles.Any())
            {
                foreach (Control dragHandle in _dragHandles)
                {
                    // Add PointerEvent-Handlers to dragHandle instead of AssociatedObject
                }
            }
            else
            {
                // Add PointerEvent-Handlers to AssociatedControl
            }
```

## Dependency on Linq

I am using `Where()` and `Any()` in the draghandle logic, since `GetVisualDescendants()` returns an `IEnumerable`.
Should I use `ToList()` instead and loop over its elements to avoid the the `Linq` dependency, or does that not matter?
